### PR TITLE
fix expo go build issue related to tailwind

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
-    "android": "expo run:android",
-    "ios": "expo run:ios",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
     "web": "expo start --web",
     "test": "jest --watchAll",
     "lint": "expo lint"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web",
     "test": "jest --watchAll",
     "lint": "expo lint"
@@ -33,7 +33,6 @@
     "expo": "^52.0.0-canary-20240814-ce0f7d5",
     "expo-constants": "17.0.0-canary-20240814-ce0f7d5",
     "expo-font": "13.0.0-canary-20240814-ce0f7d5",
-    "expo-haptics": "^13.0.1",
     "expo-linking": "^6.3.1",
     "expo-router": "4.0.0-canary-20240814-ce0f7d5",
     "expo-splash-screen": "1.0.0-canary-20240814-ce0f7d5",
@@ -52,7 +51,6 @@
     "react-native-web": "~0.19.10",
     "react-native-webview": "13.8.6",
     "recharts": "^2.12.7",
-    "tailwind": "^4.0.0",
     "tailwind-merge": "^2.4.0",
     "tailwindcss-animate": "^1.0.7"
   },
@@ -65,6 +63,7 @@
     "jest": "^29.2.1",
     "jest-expo": "52.0.0-canary-20240814-ce0f7d5",
     "react-test-renderer": "18.2.0",
+    "tailwind": "^4.0.0",
     "typescript": "~5.3.3"
   },
   "private": true


### PR DESCRIPTION
fixes build error related to tailwind when running app with the start command and also a expo-haptics error. For now I removed expo-haptic from the dependencies and moved tailwind as a dev dependency.

```
/metro/src/DeltaBundler/Worker.flow.js:30:10)
Error: Loading PostCSS "tailwindcss" plugin failed: Cannot find module 'tailwindcss'
Require stack:
- /Users/rofi/Programing/expo/expo-dom-components-canary-example/noop.js

(@global.css)
    at loadPlugin (/Users/rofi/Programing/expo/expo-dom-components-canary-example/node_modules/@expo/metro-config/build/transform-worker/postcss.js:121:19)
    at /Users/rofi/Programing/expo/expo-dom-components-canary-example/node_modules/@expo/metro-config/build/transform-worker/postcss.js:55:20
    at Array.map (<anonymous>)
    at parsePostcssConfigAsync (/Users/rofi/Programing/expo/expo-dom-components-canary-example/node_modules/@expo/metro-config/build/transform-worker/postcss.js:52:36)
    at processWithPostcssInputConfigAsync (/Users/rofi/Programing/expo/expo-dom-components-canary-example/node_modules/@expo/metro-config/build/transform-worker/postcss.js:36:47)
    at transformPostCssModule (/Users/rofi/Programing/expo/expo-dom-components-canary-example/node_modules/@expo/metro-config/build/transform-worker/postcss.js:26:20)
    at Object.transform (/Users/rofi/Programing/expo/expo-dom-components-canary-example/node_modules/@expo/metro-config/build/transform-worker/transform-worker.js:118:71)
    at transformFile (/Users/rofi/Programing/expo/expo-dom-components-canary-example/node_modules/metro/src/DeltaBundler/Worker.flow.js:54:36)
    at Object.transform (/Users/rofi/Programing/expo/expo-dom-components-canary-example/node_modules/metro/src/DeltaBundler/Worker.flow.js:30:10)```